### PR TITLE
Fix reference operator precedence

### DIFF
--- a/src/XLParser.Tests/ParserTests.cs
+++ b/src/XLParser.Tests/ParserTests.cs
@@ -53,11 +53,18 @@ namespace XLParser.Tests
             {
                 Assert.IsTrue(condition.Invoke(p.SkipToRelevant()), "condition failed for input '{0}'", input);
             }
+            // Also do a print test for every parse
+            PrintTests.test(formula: input, parsed: p);
         }
 
         private void test(IEnumerable<string> inputs, Predicate<ParseTreeNode> condition = null)
         {
-            foreach (string input in inputs) test(input, condition);
+            foreach (string input in inputs)
+               test(input, condition);
+        }
+
+        private void test(params string[] inputs) {
+            foreach (string input in inputs) test(input);
         }
 
         
@@ -81,6 +88,8 @@ namespace XLParser.Tests
             test("DAYS360(1)", node => node.IsFunction() && node.GetFunction() == "DAYS360");
             test("SUM(1)", node => node.IsFunction() && node.GetFunction() == "SUM");
             test("INDEX(1)", node => node.IsFunction() && node.GetFunction() == "INDEX");
+            test("IF(1)", node => node.IsFunction() && node.GetFunction() == "IF");
+            test("MYUSERDEFINEDFUNCTION()", node => node.IsFunction() && node.GetFunction() == "MYUSERDEFINEDFUNCTION");
         }
 
         [TestMethod]
@@ -92,7 +101,7 @@ namespace XLParser.Tests
         [TestMethod]
         public void ExternalUserDefinedFunction()
         {
-            test("[1]!myFunction()", node => node.IsFunction() && node.GetFunction() == "MYFUNCTION");
+            test("[1]!myFunction()", node => node.IsFunction() && node.GetFunction() == "[1]!MYFUNCTION");
         }
 
         [TestMethod]
@@ -627,6 +636,11 @@ namespace XLParser.Tests
         public void PercentIsFunction()
         {
             test("1%", node => node.IsFunction() && node.GetFunction() == "%");
+        }
+
+        public void FunctionsAsRefExpressions()
+        {
+            test("IF(TRUE,A1,A2):B5", "INDEX():B5", "MyUDFunction:B5", "Sheet!MyUDFunction:B5");
         }
     }
 }

--- a/src/XLParser.Tests/PrintTests.cs
+++ b/src/XLParser.Tests/PrintTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Text.RegularExpressions;
 using XLParser;
+using Irony.Parsing;
 
 namespace XLParser.Tests
 {
@@ -168,16 +169,26 @@ namespace XLParser.Tests
             }
         }
 
-        private static void test(string formula, bool ignorewhitespace = true)
+        internal static void test(string formula, bool ignorewhitespace = true, ParseTreeNode parsed = null)
         {
-            var printed = ExcelFormulaParser.Parse(formula).Print();
-            if (ignorewhitespace)
+            if (parsed == null)
             {
-                formula = formula.Replace(" ", "");
-                printed = printed.Replace(" ", "");
+                parsed = ExcelFormulaParser.Parse(formula);
             }
-            Assert.AreEqual(formula, printed);
+            try
+            {
+                var printed = parsed.Print();
+                if (ignorewhitespace)
+                {
+                    formula = formula.Replace(" ", "");
+                    printed = printed.Replace(" ", "");
+                }
+                Assert.AreEqual(formula, printed, "Printed parsed formula differs from original.\nOriginal: '{0}'\nPrinted: '{1}'", formula, printed);
+            }
+            catch (ArgumentException e)
+            {
+                Assert.Fail("Parse Tree contains a node for which the Print function is not defined.\n{0}", e.Message);
+            }
         }
-
     }
 }

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace XLParser
 {
-    [Language("Excel Formulas", "1.1.0", "Grammar for Excel Formulas")]
+    [Language("Excel Formulas", "1.1.1", "Grammar for Excel Formulas")]
     public class ExcelFormulaGrammar : Grammar
     {
         public ExcelFormulaGrammar() : base(false)
@@ -338,8 +338,9 @@ namespace XLParser
             RegisterOperators(Precedence.Multiplication, Associativity.Left, mulop, divop);
             RegisterOperators(Precedence.Exponentiation, Associativity.Left, expop);
             RegisterOperators(Precedence.UnaryPostFix, Associativity.Left, percentop);
-            RegisterOperators(Precedence.Reference, Associativity.Left, intersectop, colon);
-            RegisterOperators(Precedence.Reference, Associativity.Left, comma);
+            RegisterOperators(Precedence.Union, Associativity.Left, comma);
+            RegisterOperators(Precedence.Intersection, Associativity.Left, intersectop);
+            RegisterOperators(Precedence.Range, Associativity.Left, colon);
 
             //RegisterOperators(Precedence.ParameterSeparator, comma);
 
@@ -359,7 +360,10 @@ namespace XLParser
             public const int Exponentiation = 5;
             public const int UnaryPostFix = 6;
             public const int UnaryPreFix = 7;
-            public const int Reference = 8;
+            //public const int Reference = 8;
+            public const int Union = 9;
+            public const int Intersection = 10;
+            public const int Range = 11;
         }
 
         // Terminal priorities, indicates to lexer which token it should pick when multiple tokens can match

--- a/src/XLParser/ExcelFormulaGrammar.cs
+++ b/src/XLParser/ExcelFormulaGrammar.cs
@@ -140,7 +140,6 @@ namespace XLParser
             var File = new NonTerminal(GrammarNames.File);
             var Formula = new NonTerminal(GrammarNames.Formula);
             var FormulaWithEq = new NonTerminal(GrammarNames.FormulaWithEq);
-            var Function = new NonTerminal(GrammarNames.Function);
             var FunctionCall = new NonTerminal(GrammarNames.FunctionCall);
             var HRange = new NonTerminal(GrammarNames.HorizontalRange);
             var InfixOp = new NonTerminal(GrammarNames.TransientInfixOp);
@@ -154,6 +153,7 @@ namespace XLParser
             var Reference = new NonTerminal(GrammarNames.Reference);
             var ReferenceFunction = new NonTerminal(GrammarNames.ReferenceFunction);
             var ReferenceItem = new NonTerminal(GrammarNames.TransientReferenceItem);
+            var ReferenceOperation = new NonTerminal(GrammarNames.ReferenceOperation);
             var RefError = new NonTerminal(GrammarNames.RefError);
             var ReservedName = new NonTerminal(GrammarNames.ReservedName);
             var Sheet = new NonTerminal(GrammarNames.Sheet);
@@ -207,13 +207,11 @@ namespace XLParser
             #region Functions
 
             FunctionCall.Rule =
-                  Function + Arguments + CloseParen
+                  ExcelFunction + Arguments + CloseParen
                 | PrefixOp + Formula
                 | Formula + PostfixOp
                 | Formula + InfixOp + Formula
                 ;
-
-            Function.Rule = ExcelFunction | UDFToken;
 
             Arguments.Rule = MakeStarRule(Arguments, comma, Argument);
             //Arguments.Rule = Argument | Argument + comma + Arguments;
@@ -251,15 +249,17 @@ namespace XLParser
             #region References
 
             Reference.Rule = ReferenceItem
-                | Reference + colon + Reference
-                | Reference + intersectop + Reference
-                | OpenParen + Union + CloseParen
+                | ReferenceOperation
                 | OpenParen + Reference + PreferShiftHere() + CloseParen
                 | Prefix + ReferenceItem
-                | Prefix + UDFToken + Arguments + CloseParen
                 | DynamicDataExchange
                 ;
 
+            ReferenceOperation.Rule =
+                  Reference + colon + Reference
+                | Reference + intersectop + Reference
+                | OpenParen + Union + CloseParen
+                ;
             Union.Rule = MakePlusRule(Union, comma, Reference);
 
             ReferenceItem.Rule =
@@ -276,7 +276,9 @@ namespace XLParser
             HRange.Rule = HRangeToken;
 
             ReferenceFunction.Rule =
-                ExcelRefFunctionToken + Arguments + CloseParen;
+                  ExcelRefFunctionToken + Arguments + CloseParen
+                | UDFToken + Arguments + CloseParen
+                ;
 
             QuotedFileSheet.Rule = QuotedFileSheetToken;
             Sheet.Rule = SheetToken;
@@ -770,6 +772,7 @@ namespace XLParser
         public const string Range = "Range";
         public const string Reference = "Reference";
         public const string ReferenceFunction = "ReferenceFunction";
+        public const string ReferenceOperation = "ReferenceOperation";
         public const string RefError = "RefError";
         public const string ReservedName = "ReservedName";
         public const string Sheet = "Sheet";

--- a/src/XLParser/ExcelFormulaParser.cs
+++ b/src/XLParser/ExcelFormulaParser.cs
@@ -367,8 +367,7 @@ namespace XLParser
                         if (input.IsIntersection())
                         {
                             format = "{0} {2}";
-                        }
-                        if (input.IsBinaryReferenceOperation())
+                        }else if (input.IsBinaryReferenceOperation())
                         {
                             format = "{0}{1}{2}";
                         }


### PR DESCRIPTION
Fixes #4 

Note that this branch is based on [grammar/udf-as-reference](https://github.com/PerfectXL/XLParser/tree/grammar/udf-as-reference), so best to first merge #5 before comparing/merging this.